### PR TITLE
Closes #5: Link Sharing

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -20,6 +20,27 @@
 @import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 
 .flex { display: flex; }
+form div input.hidden-none-display { display: none; }
+ul#sources-list p span,
+ul#sources-list p  {
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #dbdbdb;
+  border-radius: .375em;
+  box-shadow: none;
+  box-sizing: border-box;
+  color: #363636;
+  cursor: pointer;
+  font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 1rem;
+  height: 2.5em;
+  line-height: 1.5;
+  padding: calc(.5em - 1px) 1em;
+  text-align: center;
+  touch-action: manipulation;
+  vertical-align: top;
+  white-space: nowrap;
+}
 
 .justify-apart { justify-content: space-between; }
 #usersFilterList > ul > li { display: flex; justify-content: space-between; }
@@ -71,22 +92,22 @@
 }
 
 <%# html body a, html body li, html body p, a {
-  color: white;  
+  color: white;
 }
 
-textarea { 
-  box-shadow: rgba(0, 0, 0, 0.02) 0px 1px 3px 0px, rgba(27, 31, 35, 0.15) 0px 0px 0px 1px; 
+textarea {
+  box-shadow: rgba(0, 0, 0, 0.02) 0px 1px 3px 0px, rgba(27, 31, 35, 0.15) 0px 0px 0px 1px;
 }
 
 input { background: inherit; color: white; }
 
 body a:hover {
   color: black;
-  background-color: yellow;  
+  background-color: yellow;
 } %>
 
-<%# 
-.bannerImage { 
+<%#
+.bannerImage {
   background-image: url(<%= asset_path 'banner-opaque.png' );
   background-size: cover;
 } %>
@@ -159,25 +180,25 @@ html body div div.bp4-active {
   background: transparent !important
 }
 
-body div#root div filter-input input { 
-  width: 40%; 
+body div#root div filter-input input {
+  width: 40%;
   margin: 2%;
   height: fit-content;
 }
-.stack-biblio  { 
+.stack-biblio  {
                 display : flex;
-                justify-content: space-around; 
+                justify-content: space-around;
               }
 
 .sidebar      { width   : 15% ; }
-.tabs         { 
-  width   : 95% ; 
+.tabs         {
+  width   : 95% ;
   height  : 85vh;
 }
 .tabs > div   { width   : 100%; }
 .reading-area { width   : 80%;  }
 .tabs,
-#search-bar input, 
+#search-bar input,
 #chat-input input  {
   display: flex;
   margin-left: auto;
@@ -307,11 +328,11 @@ details.chat-toggle > summary {
   display: flex;
 }
 
-.messages .message.left .avatar  { 
+.messages .message.left .avatar  {
   left: -35px;
   bottom: -15px;
 }
-.messages .message.right .avatar { 
+.messages .message.right .avatar {
   right: 0px;
   bottom: -45px;
 }
@@ -418,7 +439,7 @@ details.chat-toggle > summary {
 .tagsHolder {
   margin-right: 2%;
   margin-left: 2%;
-} 
+}
 .message-input {
   margin: 2%;
 }
@@ -426,8 +447,8 @@ details.chat-toggle > summary {
   color: transparent;
 }
 /* .chat form.message-box input { background: inherit; color: unset; } */
-.chat .message-box textarea { 
-  background: inherit; 
+.chat .message-box textarea {
+  background: inherit;
   /* color: white;  */
   width: 90%;
 }

--- a/app/controllers/concerns/thredded/new_post_params.rb
+++ b/app/controllers/concerns/thredded/new_post_params.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Thredded
+  # @api private
+  module NewPostParams
+    protected
+
+    def new_post_params
+      params.fetch(:post, {}).permit(:content, :quote_post_id, :websites).tap do |p|
+        quote_id = p.delete(:quote_post_id)
+        if quote_id
+          post = Thredded::Post.find(quote_id)
+          authorize_reading(post)
+          p[:quote_post] = post
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/thredded/new_topic_params.rb
+++ b/app/controllers/concerns/thredded/new_topic_params.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Thredded
+  # @api private
+  module NewTopicParams
+    protected
+
+    def new_topic_params
+      mergeable   = { messageboard: messageboard, user: thredded_current_user }
+      permissable = %i[title websites locked sticky content]
+
+      params.fetch(:topic, {}).permit(*permissable, category_ids: []).merge(**mergeable)
+    end
+  end
+end

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Thredded
+  # A controller for managing {Post}s.
+  class PostsController < Thredded::ApplicationController
+    include ActionView::RecordIdentifier
+    include Thredded::NewPostParams
+
+    helper_method :topic
+    before_action :assign_messageboard_for_actions, only: %i[mark_as_read mark_as_unread]
+    after_action :update_user_activity
+
+    after_action :verify_authorized
+
+    def new
+      @post_form = Thredded::PostForm.new(**form_params)
+
+      authorize_creating(@post_form.post)
+    end
+
+    def create
+      @post_form = Thredded::PostForm.new(**form_params)
+      authorize_creating(@post_form.post)
+
+      if @post_form.save
+        redirect_to post_path(@post_form.post, user: thredded_current_user)
+      else
+        render :new
+      end
+    end
+
+    def edit
+      @post_form = Thredded::PostForm.for_persisted(post)
+      authorize @post_form.post, :update?
+      return redirect_to(canonical_topic_params) unless params_match?(canonical_topic_params)
+
+      render
+    end
+
+    def update
+      authorize post, :update?
+      post.update(new_post_params)
+
+      redirect_to post_path(post, user: thredded_current_user)
+    end
+
+    def destroy
+      authorize post, :destroy?
+      post.destroy!
+
+      redirect_back fallback_location: topic_url(topic),
+                    notice: I18n.t('thredded.posts.deleted_notice')
+    end
+
+    def mark_as_read
+      auth_post_read
+
+      UserTopicReadState.touch!(thredded_current_user.id, post)
+
+      respond_to do |format|
+        format.html { redirect_back fallback_location: post_path(post, user: thredded_current_user) }
+        format.json { render(json: { read: true }) }
+      end
+    end
+
+    def mark_as_unread
+      auth_post_read
+
+      post.mark_as_unread(thredded_current_user)
+
+      respond_to do |format|
+        format.html { after_mark_as_unread } # customization hook
+        format.json { render(json: { read: false }) }
+      end
+    end
+
+    def quote
+      authorize_reading(post)
+
+      render(plain: Thredded::ContentFormatter.quote_content(post.content))
+    end
+
+    private
+
+    def auth_post_read
+      authorize(post, :read?)
+    end
+
+    def form_params
+      { user: thredded_current_user, topic: parent_topic, post_params: new_post_params }
+    end
+
+    def canonical_topic_params
+      { messageboard_id: messageboard.slug, topic_id: topic.slug }
+    end
+
+    def after_mark_as_unread
+      redirect_to messageboard_topics_path(messageboard)
+    end
+
+    def topic
+      post.postable
+    end
+
+    def parent_topic
+      Thredded::Topic.where(messageboard: messageboard).friendly_find!(params[:topic_id])
+    end
+
+    def assign_messageboard_for_actions
+      @messageboard = post.postable.messageboard
+    end
+
+    def post
+      @post ||= Thredded::Post.find!(params[:id])
+    end
+
+    def current_page
+      params[:page].nil? ? 1 : params[:page].to_i
+    end
+  end
+end

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+module Thredded
+  class TopicsController < Thredded::ApplicationController # rubocop:disable Metrics/ClassLength
+    include Thredded::NewTopicParams
+    include Thredded::NewPostParams
+
+    before_action :thredded_require_login!,
+                  only: %i[edit new update create destroy follow unfollow unread]
+
+    before_action :verify_messageboard,
+                  only: %i[index search unread]
+
+    before_action :use_topic_messageboard,
+                  only: %i[show edit update destroy follow unfollow]
+
+    after_action :update_user_activity
+
+    after_action :verify_authorized, except: %i[search unread]
+    after_action :verify_policy_scoped, except: %i[show new create edit update destroy follow unfollow]
+
+    def index
+      page_scope = policy_scope(messageboard.topics)
+        .order_sticky_first.order_recently_posted_first
+        .includes(:categories, :last_user, :user)
+        .send(Kaminari.config.page_method_name, current_page)
+      return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
+      @topics = Thredded::TopicsPageView.new(thredded_current_user, page_scope)
+      @new_topic = init_new_topic
+    end
+
+    def unread
+      page_scope = topics_scope
+        .unread(thredded_current_user)
+        .order_followed_first(thredded_current_user).order_recently_posted_first
+        .includes(:categories, :last_user, :user)
+        .send(Kaminari.config.page_method_name, current_page)
+      return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
+      @topics = Thredded::TopicsPageView.new(thredded_current_user, page_scope)
+      @new_topic = init_new_topic
+    end
+
+    def search
+      @query = params[:q].to_s
+      page_scope = topics_scope
+        .search_query(@query)
+        .order_recently_posted_first
+        .includes(:categories, :last_user, :user)
+        .send(Kaminari.config.page_method_name, current_page)
+      return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
+      @topics = Thredded::TopicsPageView.new(thredded_current_user, page_scope)
+    end
+
+    def show
+      authorize topic, :read?
+      return redirect_to(canonical_topic_params) unless params_match?(canonical_topic_params)
+      page_scope = policy_scope(topic.posts)
+        .order_oldest_first
+        .includes(:user, :messageboard)
+        .send(Kaminari.config.page_method_name, current_page)
+      return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
+      @posts = Thredded::TopicPostsPageView.new(thredded_current_user, topic, page_scope)
+      Thredded::UserTopicReadState.touch!(thredded_current_user.id, page_scope.last) if thredded_signed_in?
+      @new_post = Thredded::PostForm.new(user: thredded_current_user, topic: topic, post_params: new_post_params)
+    end
+
+    def new
+      @new_topic = Thredded::TopicForm.new(new_topic_params)
+      authorize_creating @new_topic.topic
+      return redirect_to(canonical_messageboard_params) unless params_match?(canonical_messageboard_params)
+      render
+    end
+
+    def category
+      authorize_reading messageboard
+      @category = messageboard.categories.friendly.find(params[:category_id])
+      @topics = Thredded::TopicsPageView.new(
+        thredded_current_user,
+        policy_scope(@category.topics)
+          .unstuck
+          .order_recently_posted_first
+          .send(Kaminari.config.page_method_name, current_page)
+      )
+      render :index
+    end
+
+    def create
+      @new_topic = Thredded::TopicForm.new(new_topic_params)
+      authorize_creating @new_topic.topic
+      if @new_topic.save
+        redirect_to next_page_after_create(params[:next_page])
+      else
+        render :new
+      end
+    end
+
+    def edit
+      authorize topic, :update?
+      return redirect_to(canonical_topic_params) unless params_match?(canonical_topic_params)
+      @edit_topic = Thredded::EditTopicForm.new(user: thredded_current_user, topic: topic)
+    end
+
+    def update
+      topic.assign_attributes(topic_params_for_update)
+      authorize topic, :update?
+      if topic.messageboard_id_changed?
+        # Work around the association not being reset.
+        # TODO: report issue to Rails. Looks like a regression of:
+        # https://rails.lighthouseapp.com/projects/8994/tickets/2989
+        topic.messageboard = Thredded::Messageboard.find(topic.messageboard_id)
+
+        authorize topic.messageboard, :post?
+      end
+      @edit_topic = Thredded::EditTopicForm.new(user: thredded_current_user, topic: topic)
+      if @edit_topic.save
+        redirect_to messageboard_topic_url(topic.messageboard, topic),
+                    notice: t('thredded.topics.updated_notice')
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      authorize topic, :destroy?
+      topic.destroy!
+      redirect_to messageboard_topics_path(messageboard),
+                  notice: t('thredded.topics.deleted_notice')
+    end
+
+    def follow
+      authorize topic, :read?
+      Thredded::UserTopicFollow.create_unless_exists(thredded_current_user.id, topic.id)
+      follow_change_response(following: true)
+    end
+
+    def unfollow
+      authorize topic, :read?
+      Thredded::UserTopicFollow.find_by(topic_id: topic.id, user_id: thredded_current_user.id).try(:destroy)
+      follow_change_response(following: false)
+    end
+
+    private
+
+    def next_page_after_create(next_page)
+      case next_page
+      when 'messageboard', '', nil
+        return messageboard_topics_path(messageboard)
+      when 'topic'
+        messageboard_topic_path(messageboard, @new_topic.topic)
+      when %r{\A/[^/]\S+\z}
+        next_page
+      else
+        fail "Unexpected value for next page: #{next_page.inspect}"
+      end
+    end
+
+    def in_messageboard?
+      params.key?(:messageboard_id)
+    end
+
+    def init_new_topic
+      return unless in_messageboard?
+      form = Thredded::TopicForm.new(messageboard: messageboard, user: thredded_current_user)
+      form if policy(form.topic).create?
+    end
+
+    def verify_messageboard
+      return unless in_messageboard?
+      authorize_reading messageboard
+      return if params_match?(canonical_messageboard_params)
+      skip_policy_scope
+      redirect_to(canonical_messageboard_params)
+    end
+
+    def canonical_messageboard_params
+      { messageboard_id: messageboard.slug }
+    end
+
+    def canonical_topic_params
+      { messageboard_id: messageboard.slug, id: topic.slug }
+    end
+
+    def follow_change_response(following:)
+      notice = following ? t('thredded.topics.followed_notice') : t('thredded.topics.unfollowed_notice')
+      respond_to do |format|
+        format.html { redirect_to messageboard_topic_url(messageboard, topic), notice: notice }
+        format.json { render(json: { follow: following }) }
+      end
+    end
+
+    # Returns the `@topic` instance variable.
+    # If `@topic` is not set, it first sets it to the topic with the slug or ID given by `params[:id]`.
+    #
+    # @return [Thredded::Topic]
+    # @raise [Thredded::Errors::TopicNotFound] if the topic with the given slug does not exist.
+    def topic
+      @topic ||= Thredded::Topic.friendly_find!(params[:id])
+    end
+
+    # Use the topic's messageboard instead of the one specified in the URL,
+    # to account for `params[:messageboard_id]` pointing to the wrong messageboard
+    def use_topic_messageboard
+      @messageboard = topic.messageboard
+    end
+
+    def topic_params_for_update
+      params
+        .require(:topic)
+        .permit(:title, :locked, :sticky, :messageboard_id, category_ids: [], submitted_links: [])
+    end
+
+    def current_page
+      (params[:page] || 1).to_i
+    end
+  end
+end

--- a/app/forms/thredded/post_form.rb
+++ b/app/forms/thredded/post_form.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Thredded
+  class PostForm
+    attr_accessor :websites
+    attr_reader :post, :topic
+    delegate :id,
+             :persisted?,
+             :content,
+             :content=,
+             to: :@post
+
+    # @param user [Thredded.user_class]
+    # @param topic [Topic]
+    # @param post [Post]
+    # @param post_params [Hash]
+    def initialize(user:, topic:, post: nil, post_params: {})
+      @messageboard = topic.messageboard
+      @topic = topic
+      @post = post || topic.posts.build
+      user ||= Thredded::NullUser.new
+
+      post_params[:content]  = Thredded::ContentFormatter.quote_content(post_params.delete(:quote_post).content) if post_params.include?(:quote_post)
+      attribute_hash         = { user: (user unless user.thredded_anonymous?), messageboard: topic.messageboard }
+      post_params[:websites] = post_params[:websites].split(',') if post_params[:websites]
+      @post.attributes       = post_params.merge(attribute_hash)
+    end
+
+    def self.for_persisted(post)
+      new(user: post.user, topic: post.postable, post: post)
+    end
+
+    def submit_path
+      Thredded::UrlsHelper.url_for([@messageboard, @topic, @post, only_path: true])
+    end
+
+    def preview_path
+      if @post.persisted?
+        Thredded::UrlsHelper.messageboard_topic_post_preview_path(@messageboard, @topic, @post)
+      else
+        Thredded::UrlsHelper.preview_new_messageboard_topic_post_path(@messageboard, @topic)
+      end
+    end
+
+    def save
+      return false unless @post.valid?
+
+      was_persisted = @post.persisted?
+      @post.save!
+      Thredded::UserTopicReadState.touch!(@post.user.id, @post) unless was_persisted
+      true
+    end
+  end
+end

--- a/app/forms/thredded/topic_form.rb
+++ b/app/forms/thredded/topic_form.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Thredded
+  class TopicForm
+    include ActiveModel::Model
+
+    attr_accessor :title, :websites, :category_ids, :locked, :sticky, :content
+    attr_reader :user, :messageboard
+
+    validate :validate_children
+
+    def initialize(params = {})
+      @title = params[:title]
+      @category_ids = params[:category_ids]
+      @locked = params[:locked] || false
+      @sticky = params[:sticky] || false
+      @content = params[:content]
+      @user = params[:user] || fail('user is required')
+      @messageboard = params[:messageboard]
+    end
+
+    def self.model_name
+      Thredded::Topic.model_name
+    end
+
+    def category_options
+      messageboard.categories.map { |cat| [cat.name, cat.id] }
+    end
+
+    def save
+      return false unless valid?
+
+      ActiveRecord::Base.transaction do
+        new_topic = !topic.persisted?
+        topic.save!
+        post.save!
+        Thredded::UserTopicReadState.read_on_first_post!(user, post) if new_topic
+      end
+      true
+    end
+
+    def topic
+      @topic ||= messageboard.topics.build(
+        title: title,
+        locked: locked,
+        sticky: sticky,
+        user: non_null_user,
+        categories: topic_categories,
+      )
+    end
+
+    def post
+      @post ||= topic.posts.build(
+        content: content,
+        user: non_null_user,
+        messageboard: messageboard
+      )
+    end
+
+    def submit_path
+      Thredded::UrlsHelper.url_for([messageboard, topic, only_path: true])
+    end
+
+    def preview_path
+      Thredded::UrlsHelper.preview_new_messageboard_topic_path(messageboard)
+    end
+
+    private
+
+    # @return [Thredded.user_class, nil] return a user or nil if the user is a NullUser
+    # This is necessary because assigning a NullUser to an ActiveRecord association results in an exception.
+    def non_null_user
+      @user unless @user.thredded_anonymous?
+    end
+
+    def topic_categories
+      if category_ids
+        ids = category_ids.reject(&:empty?)
+        Thredded::Category.where(id: ids)
+      else
+        []
+      end
+    end
+
+    def validate_children
+      promote_errors(topic.errors) if topic.invalid?
+      promote_errors(post.errors) if post.invalid?
+    end
+
+    def promote_errors(child_errors)
+      child_errors.each do |attribute, message|
+        errors.add(attribute, message)
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,11 @@ application.register("filter", FilterController)
 import StackbiblioController from "./stackbiblio_controller"
 application.register("stackbiblio", StackbiblioController)
 
+import SubmissionController from "./submission_controller"
+application.register("submission", SubmissionController)
+
 import SyncerController from "./syncer_controller"
 application.register("syncer", SyncerController)
+
+import TabController from "./tab_controller"
+application.register("tab", TabController)

--- a/app/javascript/controllers/submission_controller.js
+++ b/app/javascript/controllers/submission_controller.js
@@ -1,0 +1,72 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ['sourceToAdd', 'sourcesList', 'websiteList']
+  static values  = { alreadyAddedList: Array }
+
+  // Thredded JS doesn't work well with the Stimulus Actions so we set an event listener instead
+  connect() {
+    this.websiteListTarget.value = '';
+    this.sourceToAddTarget.addEventListener('keypress', this.submitOnEnter.bind(this));
+  }
+
+  submitOnEnter(evt) { if (evt.key === 'Enter') { this.addSourceLink(); evt.preventDefault(); } }
+
+  stripPrefixAndTrailingSlashes(url) {
+    if (!url) { return false; }
+    const regexp = /(http[s]?:\/\/(www.)?)?(?<path>[^/+$]+)/igm
+    for (let result of url.matchAll(regexp)) { return result.groups.path; }
+  }
+
+  addSourceLink() {
+    const path = this.retriveLink();
+
+    if (path) { this.sourcesListTarget.append(this.linkListItem(path)); }
+  }
+
+  retriveLink() {
+    const url  = this.sourceToAddTarget.value;
+    const path = this.stripPrefixAndTrailingSlashes(url);
+
+    if (!path || this.alreadyAddedListValue.includes(path)) { return false; }
+
+    return this.updateAndClearList(path);
+  }
+
+  updateAndClearList(path) {
+    this.sourceToAddTarget.value = '';
+    const updatedList = this.alreadyAddedListValue.concat(path);
+    this.updateList(updatedList);
+    return path;
+  }
+
+  updateList(updatedList) {
+    this.alreadyAddedListValue = updatedList;
+    this.websiteListTarget.value = updatedList;
+  }
+
+  linkListItem(path) {
+    const li     = document.createElement('p')
+    const text   = document.createTextNode(path);
+    li.appendChild(text);
+    li.append(this.deletionButton(path))
+    return li;
+  }
+
+  deletionButton(path) {
+    const button             = document.createElement('span');
+    button.dataset['action'] = 'click->submission#removeCitation';
+    button.dataset['url']    = path;
+    button.innerText         = '[x]';
+    button.title             = 'Click to Remove';
+    return button;
+  }
+
+  // let's create a button which can remove the source link
+  removeCitation(evt) {
+    let values = this.alreadyAddedListValue
+    values.splice(evt.currentTarget.dataset.url);
+    this.updateList(values);
+    evt.currentTarget.parentElement.remove();
+  }
+}

--- a/app/javascript/controllers/tab_controller.js
+++ b/app/javascript/controllers/tab_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="tab"
+export default class extends Controller {
+  connect() {
+    const tabContainer = document.querySelector('div.tab-container');
+    tabContainer.querySelectorAll('div[role="tablist"] > button').forEach((button)=>{
+      button.addEventListener('click', (event)=>{
+        tabContainer.querySelector('div.tabpanel:not([hidden])').hidden = true;
+        tabContainer.querySelector(`div.tabpanel[aria-labelledby="${event.currentTarget.id}"]`).hidden = false;
+      })
+    });
+
+
+  }
+}

--- a/app/javascript/packs/chat.jsx
+++ b/app/javascript/packs/chat.jsx
@@ -146,7 +146,7 @@ class Chat extends React.Component {
     const entries = this.state.entries;
 
     return (
-      <details open className={'chat-toggle'}>
+      <details className={'chat-toggle'}>
       <summary><Icon icon={'chat'} size={40} intent={'primary'} /><span className={''}><h2 className={'auto-margin'}>Note Stack</h2></span></summary>
 
       <div className="chat">

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+module Thredded
+  class Topic < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
+    include Thredded::TopicCommon
+    include Thredded::ContentModerationState
+
+    scope :for_messageboard, ->(messageboard) { where(messageboard_id: messageboard.id) }
+
+    scope :stuck, -> { where(sticky: true) }
+    scope :unstuck, -> { where(sticky: false) }
+
+    # Using `search_query` instead of `search` to avoid conflict with Ransack.
+    scope :search_query, ->(query) { ::Thredded::TopicsSearch.new(query, self).search }
+
+    scope :order_sticky_first, -> { order(sticky: :desc) }
+    scope :order_followed_first, ->(user) {
+      user_follows = UserTopicFollow.arel_table
+      joins(arel_table.join(user_follows, Arel::Nodes::OuterJoin)
+              .on(user_follows[:topic_id].eq(arel_table[:id])
+                  .and(user_follows[:user_id].eq(user.id))).join_sources)
+        .order(Arel::Nodes::Ascending.new(user_follows[:id].eq(nil)))
+    }
+
+    scope :followed_by, ->(user) {
+      joins(:user_follows)
+        .where(thredded_user_topic_follows: { user_id: user.id })
+    }
+    scope :unread_followed_by, ->(user) { followed_by(user).unread(user) }
+
+    extend FriendlyId
+    friendly_id :slug_candidates,
+                use: %i[history reserved],
+                # Avoid route conflicts
+                reserved_words: ::Thredded::FriendlyIdReservedWordsAndPagination.new(%w[topics unread])
+
+    belongs_to :user,
+               class_name: Thredded.user_class_name,
+               inverse_of: :thredded_topics,
+               optional: true
+
+    belongs_to :messageboard,
+               counter_cache: true,
+               touch: true,
+               inverse_of: :topics
+    validates :messageboard_id, presence: true
+
+    belongs_to :user_detail,
+               primary_key:   :user_id,
+               foreign_key:   :user_id,
+               inverse_of:    :topics,
+               counter_cache: :topics_count,
+               optional: true
+
+    has_many :posts,
+             autosave: true,
+             class_name:  'Thredded::Post',
+             foreign_key: :postable_id,
+             inverse_of:  :postable,
+             dependent:   :destroy
+    has_one :first_post, # rubocop:disable Rails/InverseOf
+            -> { order_oldest_first },
+            class_name: 'Thredded::Post',
+            foreign_key: :postable_id
+    has_one :last_post, # rubocop:disable Rails/InverseOf
+            -> { order_newest_first },
+            class_name: 'Thredded::Post',
+            foreign_key: :postable_id
+
+    has_many :topic_categories, inverse_of: :topic, dependent: :delete_all
+    has_many :categories, through: :topic_categories
+    has_many :user_read_states,
+             class_name: 'Thredded::UserTopicReadState',
+             foreign_key: :postable_id,
+             inverse_of: :postable,
+             dependent: :delete_all
+    has_many :user_follows,
+             class_name: 'Thredded::UserTopicFollow',
+             inverse_of: :topic,
+             dependent: :destroy
+    has_many :followers,
+             class_name: Thredded.user_class_name,
+             source: :user,
+             through: :user_follows
+
+    delegate :name, to: :messageboard, prefix: true
+
+    after_commit :update_messageboard_last_topic, on: :update, if: -> { previous_changes.include?('moderation_state') }
+    after_commit :update_last_user_and_time_from_last_post!, if: -> { previous_changes.include?('moderation_state') }
+
+    after_commit :handle_messageboard_change_after_commit,
+                 on: :update,
+                 if: -> { previous_changes.include?('messageboard_id') }
+
+
+    # Finds the topic by its slug or ID, or raises Thredded::Errors::TopicNotFound.
+    # @param slug_or_id [String]
+    # @return [Thredded::Topic]
+    # @raise [Thredded::Errors::TopicNotFound] if the topic with the given slug does not exist.
+    def self.friendly_find!(slug_or_id)
+      friendly.find(slug_or_id)
+    rescue ActiveRecord::RecordNotFound
+      raise Thredded::Errors::TopicNotFound
+    end
+
+    class << self
+      private
+
+      # @param user [Thredded.user_class]
+      # @return [ByPostableLookup]
+      def follows_by_topic_hash(user)
+        Thredded::TopicCommon::CachingHash.from_relation(
+          Thredded::UserTopicFollow.where(user_id: user.id, topic_id: current_scope.map(&:id))
+        )
+      end
+
+      public
+
+      def post_class
+        Thredded::Post
+      end
+
+      # @param user [Thredded.user_class]
+      # @return [Array<[TopicCommon, UserTopicReadStateCommon, UserTopicFollow]>]
+      def with_read_and_follow_states(user)
+        topics = current_scope.to_a
+        if user.thredded_anonymous?
+          post_counts = post_counts_for_user_and_topics(user, topics.map(&:id))
+          topics.map do |topic|
+            [topic, Thredded::NullUserTopicReadState.new(posts_count: post_counts[topic.id] || 0), nil]
+          end
+        else
+          read_states_by_topic = read_states_by_postable_hash(user)
+          post_counts = post_counts_for_user_and_topics(
+            user, topics.reject { |topic| read_states_by_topic.key?(topic) }.map(&:id)
+          )
+          follows_by_topic = follows_by_topic_hash(user)
+          current_scope.map do |topic|
+            [
+              topic,
+              read_states_by_topic[topic] ||
+                Thredded::NullUserTopicReadState.new(posts_count: post_counts[topic.id] || 0),
+              follows_by_topic[topic]
+            ]
+          end
+        end
+      end
+    end
+
+    def public?
+      true
+    end
+
+    # @return [Thredded::PostModerationRecord, nil]
+    def last_moderation_record
+      first_post.try(:last_moderation_record)
+    end
+
+    def update_last_user_and_time_from_last_post!
+      return if destroyed?
+      scope = posts.order_newest_first
+      scope = scope.moderation_state_visible_to_all if moderation_state_visible_to_all?
+      last_post = scope.select(:user_id, :created_at).first
+      if last_post
+        update_columns(last_user_id: last_post.user_id, last_post_at: last_post.created_at, updated_at: Time.zone.now)
+      else
+        # Either a visible topic is left with no visible posts, or an invisible topic is left with no posts at all.
+        # This shouldn't happen in stock Thredded.
+        update_columns(last_user_id: nil, last_post_at: created_at, updated_at: Time.zone.now)
+      end
+    end
+
+    def should_generate_new_friendly_id?
+      title_changed?
+    end
+
+    def normalize_friendly_id(input)
+      Thredded.slugifier.call(input.to_s)
+    end
+
+    private
+
+    def slug_candidates
+      [
+        :title,
+        [:title, '-', messageboard.try(:name)],
+        [:title, '-', messageboard.try(:name), '-topic']
+      ]
+    end
+
+    def update_messageboard_last_topic
+      messageboard.update_last_topic!
+    end
+
+    def handle_messageboard_change_after_commit
+      # Update `messageboard_id` columns. These columns are a performance optimization,
+      # so use update_all to avoid validitaing, triggering callbacks, and updating the timestamps:
+      posts.update_all(messageboard_id: messageboard_id)
+      user_read_states.update_all(messageboard_id: messageboard_id)
+
+      # Update the associated messageboard metadata that Rails does not update them automatically.
+      previous_changes['messageboard_id'].each do |messageboard_id|
+        Thredded::Messageboard.reset_counters(messageboard_id, :topics, :posts)
+        Thredded::Messageboard.find(messageboard_id).update_last_topic!
+      end
+    end
+  end
+end

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Thredded
+  # A view model for PostCommon.
+  class PostView
+    delegate :filtered_content,
+             :avatar_url,
+             :created_at,
+             :user,
+             :to_model,
+             :pending_moderation?,
+             :approved?,
+             :blocked?,
+             :last_moderation_record,
+             :websites,
+             :cache_key,
+             :cache_version,
+             :cache_key_with_version,
+             to: :@post
+
+    # @param post [Thredded::PostCommon]
+    # @param policy [#create? #update? #destroy? #moderate?]
+    # @param topic_view [Thredded::TopicView]
+    # @param first_in_page [Boolean]
+    # @param first_unread_in_page [Boolean]
+    def initialize(post, policy, topic_view: nil, first_in_page: false, first_unread_in_page: false)
+      @post   = post
+      @policy = policy
+      @topic_view = topic_view
+      @first_unread_in_page = first_unread_in_page
+      @first_in_page = first_in_page
+    end
+
+    def can_reply?
+      @can_reply ||= @policy.create?
+    end
+
+    def can_update?
+      @can_update ||= @policy.update?
+    end
+
+    def can_destroy?
+      @can_destroy ||= @policy.destroy?
+    end
+
+    def can_moderate?
+      @can_moderate ||= @policy.moderate?
+    end
+
+    def quote_url_params
+      if @post.private_topic_post?
+        { post: { quote_private_post_id: @post.id } }
+      else
+        { post: { quote_post_id: @post.id } }
+      end.update(anchor: 'post_content')
+    end
+
+    def quote_path
+      Thredded::UrlsHelper.quote_post_path(@post)
+    end
+
+    def edit_path
+      Thredded::UrlsHelper.edit_post_path(@post)
+    end
+
+    def mark_unread_path
+      Thredded::UrlsHelper.mark_unread_path(@post)
+    end
+
+    def destroy_path
+      Thredded::UrlsHelper.delete_post_path(@post)
+    end
+
+    def permalink_path
+      Thredded::UrlsHelper.permalink_path(@post)
+    end
+
+    POST_IS_READ = :read
+    POST_IS_UNREAD = :unread
+
+    # returns nil if read state is not appropriate to the view (i.e. viewing posts outside a topic)
+    def read_state
+      if @topic_view.nil? || @policy.anonymous?
+        nil
+      elsif @topic_view.post_read?(@post)
+        POST_IS_READ
+      else
+        POST_IS_UNREAD
+      end
+    end
+
+    def first_unread_in_page?
+      @first_unread_in_page
+    end
+
+    def first_in_page?
+      @first_in_page
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,12 +9,11 @@
     <!-- Blueprint stylesheets -->
     <link href="https://unpkg.com/@blueprintjs/icons@^4.0.0/lib/css/blueprint-icons.css" rel="stylesheet" />
     <link href="https://unpkg.com/@blueprintjs/core@^4.0.0/lib/css/blueprint.css" rel="stylesheet" />
-    <%= stylesheet_link_tag 'thredded', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_packs_with_chunks_tag('application', 'data-turbolinks-track': 'reload') %>
   </head>
   <body class=<%= @page_name || 'default_page_type' %>>
-    <%= render('layouts/partials/navbar') %> 
+    <%= render('layouts/partials/navbar') %>
     <%= yield %>
     <%= javascript_packs_with_chunks_tag('chat') %>     <%# This has to be in the body instead of the head? %>
     <div id="react-chat-container"></div>

--- a/app/views/layouts/thredded/application.html.erb
+++ b/app/views/layouts/thredded/application.html.erb
@@ -12,7 +12,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= csrf_meta_tag %>
     <%= csp_meta_tag %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_packs_with_chunks_tag('application', 'data-turbolinks-track': 'reload') %>
     <%= javascript_include_tag 'thredded',
                                async: !Rails.application.config.assets.debug,
                                defer: true,
@@ -21,7 +21,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
   </head>
   <body>
-    <%= render('layouts/partials/navbar') %> 
+    <%= render('layouts/partials/navbar') %>
     <%= yield %>
     <%= javascript_packs_with_chunks_tag('chat') %>     <%# This has to be in the body instead of the head? %>
     <div id="react-chat-container"></div>

--- a/app/views/thredded/posts_common/_content.html.erb
+++ b/app/views/thredded/posts_common/_content.html.erb
@@ -1,4 +1,7 @@
 <div class="thredded--post--content">
   <%= post.filtered_content(self, **(local_assigns[:options] || {})) %>
+  <%- post.websites.each do |website| %>
+    <%= website %>
+  <%- end %>
 </div>
 <hr/>

--- a/app/views/thredded/posts_common/form/_content_field.html.erb
+++ b/app/views/thredded/posts_common/form/_content_field.html.erb
@@ -1,8 +1,19 @@
-<li>
   <%= form.label :content, content_label %>
   <%= view_hooks.post_form.content_text_area.render self, form: form, content_label: content_label do %>
       <%= render 'thredded/posts_common/form/before_content', form: form %>
       <%= form.text_area :content, {rows: 5, required: true, autofocus: !!params[:autofocus_new_post_content]} %>
       <%= render 'thredded/posts_common/form/after_content', form: form %>
+
+      <div data-controller="submission">
+        <div class="flex">
+          <span class="button-like" data-action="click->submission#addSourceLink">Add</span>
+          <input
+            data-submission-target="sourceToAdd"
+            placeholder='Cite your sources (recommended, but optional)'
+            autocomplete='off'>
+        </div>
+
+        <ul id='sources-list' data-submission-target='sourcesList'></ul>
+        <%= form.text_field :websites, data: { 'submission-target': 'websiteList' }, class: 'hidden-none-display' %>
+      </div>
   <% end %>
-</li>

--- a/app/views/thredded/topics/new.html.erb
+++ b/app/views/thredded/topics/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for :thredded_page_title, t('thredded.topics.create') %>
+<% content_for :thredded_page_id, 'thredded--new-topic' %>
+<% content_for :thredded_breadcrumbs, render('thredded/shared/breadcrumbs') %>
+
+<%= thredded_page do %>
+  <section class="thredded--main-section">
+    <%= render 'thredded/topics/form',
+               topic: @new_topic,
+               css_class: 'thredded--is-expanded',
+               placeholder: t('thredded.topics.form.title_placeholder_start') %>
+  </section>
+<% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -203,6 +203,7 @@ ActiveRecord::Schema.define(version: 2022_11_05_005235) do
     t.integer "moderation_state", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "websites", default: [], array: true
     t.index "to_tsvector('english'::regconfig, content)", name: "thredded_posts_content_fts", using: :gist
     t.index ["messageboard_id"], name: "index_thredded_posts_on_messageboard_id"
     t.index ["moderation_state", "updated_at"], name: "index_thredded_posts_for_display"


### PR DESCRIPTION
This change adds an option to include source/citation links with posts:
- Users can submit an optional list of links with each post
- The items on the list can be deleted and re-added
- No duplicates are allowed
- The result is stored in the database as an array and displayed with the post
- We strip any prefix with any combination of http:// or https:// or www.
- We strip trailing slashes
- Hitting 'enter' when adding links updates list without shifting keyboard focus