### PR TITLE
Closes #38 | Turbolinks vs form.requestSubmit()

### DIFF
--- a/app/views/layouts/thredded/application.html.erb
+++ b/app/views/layouts/thredded/application.html.erb
@@ -12,7 +12,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= csrf_meta_tag %>
     <%= csp_meta_tag %>
-    <%= javascript_packs_with_chunks_tag('application', 'data-turbolinks-track': 'reload') %>
+    <%= javascript_packs_with_chunks_tag('application') %>
     <%= javascript_include_tag 'thredded',
                                async: !Rails.application.config.assets.debug,
                                defer: true,


### PR DESCRIPTION
- disabled `data-turbolinks-track` in order to get form.requestSubmit() to work with turbo